### PR TITLE
create quay.io build from release with carpenter

### DIFF
--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "**"
+  release:
+    types:
+      - published
 env:
   IMAGE_NAME: arcaflow-plugin-pcp
   IMAGE_TAG: 'latest'
@@ -14,6 +17,20 @@ env:
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 jobs:
+  carpenter-build-release:
+    name: carpenter_build_release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: set_image_tag
+        run: |
+          echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Checkout this project
+        uses: actions/checkout@v3
+      - name: carpenter build
+        uses: arcalot/arcaflow-plugin-image-builder@main
+        with:
+          args: build --build --push
   carpenter-build-prod:
     name: carpenter_build_prod
     runs-on: ubuntu-latest
@@ -28,7 +45,7 @@ jobs:
   carpenter-build-dev:
     name: carpenter_build_dev
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && github.event_name != 'release'
     steps:
       - name: set_image_tag
         run: |


### PR DESCRIPTION
## Changes introduced with this PR

Added logic to carpenter to build and push a version-tagged image on release.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).