### PR TITLE
convert pmlogger_interval to a float

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ Start the PCP data logging tools
 
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>PcpInputParams</td></tr>
-<tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>int</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>int</code></td>
+<tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>float</code>)</summary>
+                <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds (float) used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>float</code></td><tr><th>Units:</th><td>nanoseconds</td></tr>
 </tbody></table>
             </details><details><summary>timeout (<code>int</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>pmlogger timeout seconds</td></tr><tr><th>Description:</th><td>Timeout in seconds after which to cancel the pmlogger collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>int</code></td>
 </tbody></table>
             </details></td></tr>
 <tr><td colspan="2"><details><summary><strong>Objects</strong></summary><details><summary>PcpInputParams (<code>object</code>)</summary>
-            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>int</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>int</code></td>
+            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>float</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds (float) used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>float</code></td><tr><th>Units:</th><td>nanoseconds</td></tr>
 </tbody></table>
         </details><details><summary>timeout (<code>int</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>pmlogger timeout seconds</td></tr><tr><th>Description:</th><td>Timeout in seconds after which to cancel the pmlogger collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>int</code></td>

--- a/arcaflow_plugin_pcp/pcp_schema.py
+++ b/arcaflow_plugin_pcp/pcp_schema.py
@@ -10,7 +10,8 @@ class PcpInputParams:
         schema.units(schema.UNIT_TIME),
         schema.name("pmlogger logging interval"),
         schema.description(
-            "The logging interval in seconds (float) used by pmlogger for data collection"
+            "The logging interval in seconds (float) used by pmlogger"
+            " for data collection"
         ),
     ] = None
     timeout: typing.Annotated[

--- a/arcaflow_plugin_pcp/pcp_schema.py
+++ b/arcaflow_plugin_pcp/pcp_schema.py
@@ -6,10 +6,11 @@ from arcaflow_plugin_sdk import plugin, schema
 @dataclass
 class PcpInputParams:
     pmlogger_interval: typing.Annotated[
-        typing.Optional[int],
+        typing.Optional[float],
+        schema.units(schema.UNIT_TIME),
         schema.name("pmlogger logging interval"),
         schema.description(
-            "The logging interval in seconds used by pmlogger for data collection"
+            "The logging interval in seconds (float) used by pmlogger for data collection"
         ),
     ] = None
     timeout: typing.Annotated[

--- a/configs/pcp_example.yaml
+++ b/configs/pcp_example.yaml
@@ -1,2 +1,2 @@
-pmlogger_interval: 1
+pmlogger_interval: 0.5
 timeout: 5

--- a/tests/test_arcaflow_plugin_pcp.py
+++ b/tests/test_arcaflow_plugin_pcp.py
@@ -14,7 +14,7 @@ class PCPTest(unittest.TestCase):
     def test_serialization():
         plugin.test_object_serialization(
             pcp_plugin.PcpInputParams(
-                pmlogger_interval=1,
+                pmlogger_interval=1.0,
             )
         )
 
@@ -40,7 +40,7 @@ class PCPTest(unittest.TestCase):
 
     def test_functional(self):
         input = pcp_plugin.PcpInputParams(
-            pmlogger_interval=1,
+            pmlogger_interval=1.0,
             timeout=5,
         )
 


### PR DESCRIPTION
## Changes introduced with this PR

The pmlogger interval accepts a float value, so the schema is updated to reflect that. I have also added the built-in `UNIT_TIME` schema to allow for other standard time values that the wrapped command accepts.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).