### PR TITLE
initial implementation to accept pmlogger config as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Start the PCP data logging tools
 
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>PcpInputParams</td></tr>
-<tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>float</code>)</summary>
+<tr><th>Properties</th><td><details><summary>pmlogger_conf (<code>string</code>)</summary>
+                <table><tbody><tr><th>Name:</th><td>pmlogger configuration file</td></tr><tr><th>Description:</th><td>Complete configuration file content for pmlogger as a multi-line string. If no config file is provided, a default one will be generated.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+            </details><details><summary>pmlogger_interval (<code>float</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds (float) used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>float</code></td><tr><th>Units:</th><td>nanoseconds</td></tr>
 </tbody></table>
             </details><details><summary>timeout (<code>int</code>)</summary>
@@ -52,7 +54,9 @@ Start the PCP data logging tools
 </tbody></table>
             </details></td></tr>
 <tr><td colspan="2"><details><summary><strong>Objects</strong></summary><details><summary>PcpInputParams (<code>object</code>)</summary>
-            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>pmlogger_interval (<code>float</code>)</summary>
+            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>pmlogger_conf (<code>string</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>pmlogger configuration file</td></tr><tr><th>Description:</th><td>Complete configuration file content for pmlogger as a multi-line string. If no config file is provided, a default one will be generated.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        </details><details><summary>pmlogger_interval (<code>float</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>pmlogger logging interval</td></tr><tr><th>Description:</th><td>The logging interval in seconds (float) used by pmlogger for data collection</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>float</code></td><tr><th>Units:</th><td>nanoseconds</td></tr>
 </tbody></table>
         </details><details><summary>timeout (<code>int</code>)</summary>

--- a/arcaflow_plugin_pcp/pcp_plugin.py
+++ b/arcaflow_plugin_pcp/pcp_plugin.py
@@ -100,22 +100,29 @@ class StartPcpStep:
             )
 
         # Create the pmlogger.conf file
-        pmlogconf_cmd = [
-            "/usr/bin/pmlogconf",
-            "pmlogger.conf",
-        ]
+        if params.pmlogger_conf:
+            print("Using provided pmlogger configuraiton file")
+            f = open("pmlogger.conf", "w")
+            f.write(params.pmlogger_conf)
+            f.close
+        else:
+            print("Generating default pmlogger configuraiton file")
+            pmlogconf_cmd = [
+                "/usr/bin/pmlogconf",
+                "pmlogger.conf",
+            ]
 
-        try:
-            subprocess.check_output(
-                pmlogconf_cmd,
-                text=True,
-            )
-        except subprocess.CalledProcessError as error:
-            return "error", Error(
-                "{} failed with return code {}:\n{}".format(
-                    error.cmd[0], error.returncode, error.output
+            try:
+                subprocess.check_output(
+                    pmlogconf_cmd,
+                    text=True,
                 )
-            )
+            except subprocess.CalledProcessError as error:
+                return "error", Error(
+                    "{} failed with return code {}:\n{}".format(
+                        error.cmd[0], error.returncode, error.output
+                    )
+                )
 
         # Start pmlogger
         pmlogger_cmd = [

--- a/arcaflow_plugin_pcp/pcp_schema.py
+++ b/arcaflow_plugin_pcp/pcp_schema.py
@@ -21,6 +21,14 @@ class PcpInputParams:
             "Timeout in seconds after which to cancel the pmlogger collection"
         ),
     ] = None
+    pmlogger_conf: typing.Annotated[
+        typing.Optional[str],
+        schema.name("pmlogger configuration file"),
+        schema.description(
+            "Complete configuration file content for pmlogger as a multi-line string."
+            " If no config file is provided, a default one will be generated."
+        ),
+    ] = None
 
 
 @dataclass


### PR DESCRIPTION
## Changes introduced with this PR

Adds the ability to pass the pmlogger configuration file as a multi-line string in the plugin input.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).