### PR TITLE
Flatten json

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Start the PCP data logging tools
 
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>PcpInputParams</td></tr>
-<tr><th>Properties</th><td><details><summary>generate_csv (<code>bool</code>)</summary>
+<tr><th>Properties</th><td><details><summary>flatten (<code>bool</code>)</summary>
+                <table><tbody><tr><th>Name:</th><td>flatten JSON structure</td></tr><tr><th>Description:</th><td>Processes the metrics first into a two-dimensional format via the pcp2csv converter, and then converts the CSV to JSON, effectively flattening the data structure. This is useful when indexing metrics to a service like Elasticsearch.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>false</code></pre></td></tr><tr><th>Type:</th><td><code>bool</code></td></tbody></table>
+            </details><details><summary>generate_csv (<code>bool</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>generate CSV output</td></tr><tr><th>Description:</th><td>Generates the data payload also in CSV format. This output goes to the debug_logs, or to stderr if the --debug flag is used.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>false</code></pre></td></tr><tr><th>Type:</th><td><code>bool</code></td></tbody></table>
             </details><details><summary>pmlogger_conf (<code>string</code>)</summary>
                 <table><tbody><tr><th>Name:</th><td>pmlogger configuration file</td></tr><tr><th>Description:</th><td>Complete configuration file content for pmlogger as a multi-line string. If no config file is provided, a default one will be generated.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
@@ -91,7 +93,9 @@ Start the PCP data logging tools
 </tbody></table>
             </details></td></tr>
 <tr><td colspan="2"><details><summary><strong>Objects</strong></summary><details><summary>PcpInputParams (<code>object</code>)</summary>
-            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>generate_csv (<code>bool</code>)</summary>
+            <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>flatten (<code>bool</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>flatten JSON structure</td></tr><tr><th>Description:</th><td>Processes the metrics first into a two-dimensional format via the pcp2csv converter, and then converts the CSV to JSON, effectively flattening the data structure. This is useful when indexing metrics to a service like Elasticsearch.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>false</code></pre></td></tr><tr><th>Type:</th><td><code>bool</code></td></tbody></table>
+        </details><details><summary>generate_csv (<code>bool</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>generate CSV output</td></tr><tr><th>Description:</th><td>Generates the data payload also in CSV format. This output goes to the debug_logs, or to stderr if the --debug flag is used.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>false</code></pre></td></tr><tr><th>Type:</th><td><code>bool</code></td></tbody></table>
         </details><details><summary>pmlogger_conf (<code>string</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>pmlogger configuration file</td></tr><tr><th>Description:</th><td>Complete configuration file content for pmlogger as a multi-line string. If no config file is provided, a default one will be generated.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>

--- a/arcaflow_plugin_pcp/pcp_plugin.py
+++ b/arcaflow_plugin_pcp/pcp_plugin.py
@@ -165,14 +165,10 @@ class StartPcpStep:
                 pcp2csv_cmd.extend(metrics)
 
                 try:
-                    csv_out = (
-                        (
-                            subprocess.check_output(
-                                pcp2csv_cmd,
-                                text=True,
-                                stderr=subprocess.STDOUT,
-                            )
-                        )
+                    csv_out = subprocess.check_output(
+                        pcp2csv_cmd,
+                        text=True,
+                        stderr=subprocess.STDOUT,
                     )
                 except subprocess.CalledProcessError as error:
                     if params.flatten:
@@ -199,11 +195,11 @@ class StartPcpStep:
                                 error.cmd[0], error.returncode, error.output
                             )
                         )
-            
+
             if params.flatten:
                 reader = csv.DictReader(csv_out.splitlines())
                 pcp_metrics_list = [row for row in reader]
-                
+
             else:
                 try:
                     pcp_out = (
@@ -219,7 +215,6 @@ class StartPcpStep:
                     )
                     pcp_out_json = json.loads(pcp_out)
                     pcp_metrics_list = pcp_out_json["@pcp"]["@hosts"][0]["@metrics"]
-
 
                 except subprocess.CalledProcessError as error:
                     # If the pcp2json command fails, we first attempt to retry.
@@ -246,7 +241,6 @@ class StartPcpStep:
 
             # If pcp2json or pcp2csv completes without an exception, we return success.
             return "success", PerfOutput(pcp_metrics_list)
-            
 
         # Since the above while loop should always return either success or error,
         # and should never come to its natural end, if we get here, something

--- a/arcaflow_plugin_pcp/pcp_schema.py
+++ b/arcaflow_plugin_pcp/pcp_schema.py
@@ -53,7 +53,7 @@ class PcpInputParams:
             "pcp2csv converter, and then converts the CSV to JSON, effectively "
             "flattening the data structure. This is useful when indexing metrics "
             "to a service like Elasticsearch."
-        )
+        ),
     ] = False
 
 

--- a/arcaflow_plugin_pcp/pcp_schema.py
+++ b/arcaflow_plugin_pcp/pcp_schema.py
@@ -45,6 +45,16 @@ class PcpInputParams:
             "the debug_logs, or to stderr if the --debug flag is used."
         ),
     ] = False
+    flatten: typing.Annotated[
+        typing.Optional[bool],
+        schema.name("flatten JSON structure"),
+        schema.description(
+            "Processes the metrics first into a two-dimensional format via the "
+            "pcp2csv converter, and then converts the CSV to JSON, effectively "
+            "flattening the data structure. This is useful when indexing metrics "
+            "to a service like Elasticsearch."
+        )
+    ] = False
 
 
 @dataclass

--- a/tests/test_arcaflow_plugin_pcp.py
+++ b/tests/test_arcaflow_plugin_pcp.py
@@ -115,7 +115,24 @@ class PCPTest(unittest.TestCase):
         input = pcp_plugin.PcpInputParams(
             pmlogger_interval=1.0,
             pmlogger_metrics="kernel.all.cpu.user mem.util.used",
-            timeout=5,
+            timeout=3,
+        )
+
+        output_id, output_data = pcp_plugin.StartPcpStep.start_pcp(
+            params=input, run_id="ci_pcp"
+        )
+
+        print(f"==>> output_id is {output_id}")
+        print(f"==>> output_data is {output_data}")
+
+        self.assertEqual("success", output_id)
+        self.assertIsInstance(output_data.pcp_output, list)
+
+    def test_functional_flat(self):
+        input = pcp_plugin.PcpInputParams(
+            pmlogger_interval=1.0,
+            pmlogger_metrics="kernel.all.cpu.user mem.util.used",
+            timeout=3,
             flatten=True,
         )
 

--- a/tests/test_arcaflow_plugin_pcp.py
+++ b/tests/test_arcaflow_plugin_pcp.py
@@ -17,6 +17,7 @@ class PCPTest(unittest.TestCase):
             )
         )
 
+        # Normal output
         plugin.test_object_serialization(
             pcp_plugin.PerfOutput(
                 pcp_output=[
@@ -70,6 +71,44 @@ class PCPTest(unittest.TestCase):
             )
         )
 
+        # Flattened output
+        plugin.test_object_serialization(
+            pcp_plugin.PerfOutput(
+                pcp_output=[
+                    {
+                        "Time": "2024-01-17T17:36:49.989464",
+                        "kernel.all.load-1 minute": "",
+                        "kernel.all.load-5 minute": "",
+                        "kernel.all.load-15 minute": "",
+                        "mem.util.used": "",
+                        "mem.util.free": "",
+                        "mem.util.shared": "",
+                        "mem.util.bufmem": "",
+                        "mem.util.cached": "",
+                        "mem.util.other": "",
+                        "mem.util.swapCached": "",
+                        "mem.util.active": "",
+                        "mem.util.inactive": "",
+                    },
+                    {
+                        "Time": "2024-01-17T17:36:50.989464",
+                        "kernel.all.load-1 minute": "0.600000",
+                        "kernel.all.load-5 minute": "0.520000",
+                        "kernel.all.load-15 minute": "0.550000",
+                        "mem.util.used": "30313328",
+                        "mem.util.free": "2045216",
+                        "mem.util.shared": "",
+                        "mem.util.bufmem": "256",
+                        "mem.util.cached": "18092256",
+                        "mem.util.other": "12220816",
+                        "mem.util.swapCached": "144",
+                        "mem.util.active": "12740016",
+                        "mem.util.inactive": "10679792",
+                    },
+                ]
+            )
+        )
+
         plugin.test_object_serialization(pcp_plugin.Error(error="This is an error"))
 
     def test_functional(self):
@@ -77,6 +116,7 @@ class PCPTest(unittest.TestCase):
             pmlogger_interval=1.0,
             pmlogger_metrics="kernel.all.cpu.user mem.util.used",
             timeout=5,
+            flatten=True,
         )
 
         output_id, output_data = pcp_plugin.StartPcpStep.start_pcp(


### PR DESCRIPTION
## Changes introduced with this PR

The default output structure includes nested lists, which Elastic/Opensearch cannot parse into metrics for the time series. This enhancement adds an input option to flatten the output. When the user provides the `flatten: True` option the plugin, the `pcp2csv` command will be used instead of `pcp2json`, resulting in a 2-dimensional data set, which is then processed back in as a dictionary.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).